### PR TITLE
Add HTTP 503 status retry functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ dist
 dist-newstyle
 docs
 cabal.project.local
+cabal.project.local~
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work/
+.ghc.environment.*

--- a/client/haskell-bitmex-client.cabal
+++ b/client/haskell-bitmex-client.cabal
@@ -105,6 +105,7 @@ test-suite test-haskell-bitmex-client
 
   build-depends:        base
                       , text
+                      , time
                       , http-client
                       , http-client-tls
                       , haskell-bitmex-rest

--- a/client/haskell-bitmex-client.cabal
+++ b/client/haskell-bitmex-client.cabal
@@ -104,7 +104,10 @@ test-suite test-haskell-bitmex-client
   ghc-options:        -Wall -fno-warn-orphans
 
   build-depends:        base
-                      -- , haskell-bitmex-rest
+                      , text
+                      , http-client
+                      , http-client-tls
+                      , haskell-bitmex-rest
                       , haskell-bitmex-client
                       , tasty
                       , tasty-hunit

--- a/client/haskell-bitmex-client.cabal
+++ b/client/haskell-bitmex-client.cabal
@@ -96,3 +96,17 @@ executable example
                      , time >=1.5 && <1.9
                      , websockets >= 0.12
   default-language:    Haskell2010
+
+test-suite test-haskell-bitmex-client
+  type:               exitcode-stdio-1.0
+  main-is:            Test.hs
+  hs-source-dirs:     test
+  ghc-options:        -Wall -fno-warn-orphans
+
+  build-depends:        base
+                      -- , haskell-bitmex-rest
+                      , haskell-bitmex-client
+                      , tasty
+                      , tasty-hunit
+
+  default-language:   Haskell2010

--- a/client/haskell-bitmex-client.cabal
+++ b/client/haskell-bitmex-client.cabal
@@ -112,5 +112,6 @@ test-suite test-haskell-bitmex-client
                       , haskell-bitmex-client
                       , tasty
                       , tasty-hunit
+                      , aeson
 
   default-language:   Haskell2010

--- a/client/haskell-bitmex-client.cabal
+++ b/client/haskell-bitmex-client.cabal
@@ -113,5 +113,6 @@ test-suite test-haskell-bitmex-client
                       , tasty
                       , tasty-hunit
                       , aeson
+                      , http-types
 
   default-language:   Haskell2010

--- a/client/lib/BitMEXClient/WebSockets/Types/Response.hs
+++ b/client/lib/BitMEXClient/WebSockets/Types/Response.hs
@@ -27,17 +27,15 @@ module BitMEXClient.WebSockets.Types.Response
     , Action(..)
     ) where
 
-import           BitMEX.Core
-    ( DateTime
-    )
+import           BitMEX.Core         (DateTime)
+import           Data.Text           (Text)
+import           Data.Vector         (Vector)
+
+import           Control.Applicative (pure, (<*>))
+import           Data.Aeson          ((.:), (.:?))
+
 import           BitMEXClient.CustomPrelude
 import           BitMEXClient.WebSockets.Types.General
-import           Data.Text
-    ( Text
-    )
-import           Data.Vector
-    ( Vector
-    )
 
 data Action
     = Partial
@@ -212,7 +210,73 @@ data RespExecution = RespExecution
     , timestamp             :: !(Maybe DateTime) -- ^ "timestamp"
     } deriving (Show, Eq, Generic)
 
-instance FromJSON RespExecution
+
+{- Unfortunately, we have to write an instance for parsing this because of the
+   case where the execution is just the funding fee. The response comes
+   has an empty string for the side (instead of "Buy" or "Sell") and this
+   is failing the parser.
+-}
+instance FromJSON RespExecution where
+    parseJSON = withObject "RespExecution" $ \o -> do
+        side'     :: Maybe Text <- o .:? "side"
+        execType' :: Maybe Text <- o .:? "execType"
+        text'     :: Maybe Text <- o .:? "text"
+        mSide <- case (side', execType', text') of
+            (Just ""   , Just "Funding", Just "Funding") -> return Nothing
+            (Nothing    , _ , _ ) -> return Nothing
+            (Just "Buy" , _ , _ ) -> return (Just Buy)
+            (Just "Sell", _ , _ ) -> return (Just Sell)
+            _ -> fail ("Parsing RespExecution has invalid execution \"side\" field: " <> show side')
+
+        RespExecution
+            <$> o .:  "execID"
+            <*> o .:? "orderID"
+            <*> o .:? "clOrdID"
+            <*> o .:? "clOrdLinkID"
+            <*> o .:? "account"
+            <*> o .:? "symbol"
+            <*> pure mSide
+            <*> o .:? "lastQty"
+            <*> o .:? "lastPx"
+            <*> o .:? "underlyingLastPx"
+            <*> o .:? "lastMkt"
+            <*> o .:? "lastLiquidityInd"
+            <*> o .:? "simpleOrderQty"
+            <*> o .:? "orderQty"
+            <*> o .:? "price"
+            <*> o .:? "displayQty"
+            <*> o .:? "stopPx"
+            <*> o .:? "pegOffsetValue"
+            <*> o .:? "pegPriceType"
+            <*> o .:? "currency"
+            <*> o .:? "settlCurrency"
+            <*> o .:? "execType"
+            <*> o .:? "ordType"
+            <*> o .:? "timeInForce"
+            <*> o .:? "execInst"
+            <*> o .:? "contingencyType"
+            <*> o .:? "exDestination"
+            <*> o .:? "ordStatus"
+            <*> o .:? "triggered"
+            <*> o .:? "workingIndicator"
+            <*> o .:? "ordRejReason"
+            <*> o .:? "simpleLeavesQty"
+            <*> o .:? "leavesQty"
+            <*> o .:? "simpleCumQty"
+            <*> o .:? "cumQty"
+            <*> o .:? "avgPx"
+            <*> o .:? "commission"
+            <*> o .:? "tradePublishIndicator"
+            <*> o .:? "multiLegReportingType"
+            <*> o .:? "text"
+            <*> o .:? "trdMatchID"
+            <*> o .:? "execCost"
+            <*> o .:? "execComm"
+            <*> o .:? "homeNotional"
+            <*> o .:? "foreignNotional"
+            <*> o .:? "transactTime"
+            <*> o .:? "timestamp"
+
 
 data RespFunding = RespFunding
     { timestamp        :: !DateTime -- ^ /Required/ "timestamp"

--- a/client/lib/BitMEXClient/Wrapper/Types.hs
+++ b/client/lib/BitMEXClient/Wrapper/Types.hs
@@ -1,14 +1,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
-module BitMEXClient.Wrapper.Types
-    ( BitMEXWrapperConfig(..)
-    , BitMEXReader(..)
-    , Environment(..)
-    , BitMEXApp
-    , Authenticator(..)
-    , APIKeys(..)
-    , run
-    ) where
+module BitMEXClient.Wrapper.Types where
 
 import           BitMEX
     ( AuthApiKeyApiKey (..)
@@ -38,6 +30,22 @@ data Environment
 instance Show Environment where
     show MainNet = "https://www.bitmex.com"
     show TestNet = "https://testnet.bitmex.com"
+
+-- | API credentials
+data APICredentials = APICreds
+    { apiId     :: String
+    , apiSecret :: String
+    } deriving (Generic, Show)
+
+-- | BitMEX configuration
+data BitMEX = BitMEX
+    { netEnv      :: Environment -- ^ MainNet or TestNet
+    , restPath    :: String      -- ^ base path to be prependend in REST API calls
+    , wsPath      :: String
+    , connManager :: Manager
+    , apiCreds    :: APICredentials
+    , logConfig   :: LogContext
+    } deriving Generic
 
 data APIKeys = APIKeys
     { publicKey  :: !Text

--- a/client/lib/BitMEXClient/Wrapper/Util.hs
+++ b/client/lib/BitMEXClient/Wrapper/Util.hs
@@ -15,5 +15,6 @@ sign s m = hmacGetDigest . hmac s $ m
 
 -- | Convenience function to generate a timestamp
 -- for the signature of the request.
+-- FIX ME!!! THIS MUST BE FIXED at this constant for now.
 makeTimestamp :: (RealFrac a) => a -> Int
-makeTimestamp = floor . (* 1000000)
+makeTimestamp _ = 9999999999 -- floor . (* 1000000)

--- a/client/test/Test.hs
+++ b/client/test/Test.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+-- {-# LANGUAGE OverloadedStrings #-}
+-- {-# LANGUAGE RecordWildCards #-}
+-- {-# LANGUAGE PartialTypeSignatures #-}
+
+module Main where
+
+import Data.Typeable (Proxy(..))
+
+import Test.Tasty
+import Test.Tasty.Options
+import Test.Tasty.HUnit
+
+-- import PropMime
+-- import Instances ()
+
+-- import BitMEX.Model
+-- import BitMEX.MimeTypes
+
+import BitMEXClient (Environment(..)) -- , BitMEXWrapperConfig(..)) -- , APIKeys(..))
+
+----------------------------------------
+
+newtype API_ID     = API_ID      String deriving (Show, Eq)
+newtype API_SECRET = API_SECRET  String deriving Show
+
+instance IsOption Environment where
+    defaultValue = error "User must specify MainNet/TestNet Environment (on command line or environment) for authenticated tests."
+    parseValue x
+      | x == "MainNet" = Just MainNet
+      | x == "TestNet" = Just TestNet
+      | otherwise      = Just defaultValue
+
+    optionName = return "BITMEX_ENVIRONMENT"
+    optionHelp = return "Which BitMEX environment (MainNet or TestNet) to use to run the tests."
+
+instance IsOption API_ID where
+    defaultValue = error "User must supply BITMEX_API_ID (on command line or environment) for authenticated tests."
+    parseValue = Just . API_ID
+    optionName = return "BITMEX_API_ID"
+    optionHelp = return "Customer's API ID for Bitmex account (hex encoded)."
+
+instance IsOption API_SECRET where
+    defaultValue = error "User must supply BITMEX_API_SECRET (on command line or environment) for authenticated tests."
+    parseValue = Just . API_SECRET
+    optionName = return "BITMEX_API_SECRET"
+    optionHelp = return "Customer's API secret for Bitmex account (hex encoded)."
+
+
+main :: IO ()
+main = defaultMainWithIngredients ings $
+    askOption $ \env ->
+    askOption $ \apikey ->
+    askOption $ \apiid ->
+    withResource (mkConfig env apiid apikey) (\_ -> return ()) (\config -> tests config)
+  where
+    ings = includingOptions
+        [ (Option (Proxy :: Proxy Environment))
+        , (Option (Proxy :: Proxy API_ID))
+        , (Option (Proxy :: Proxy API_SECRET))
+        ] : defaultIngredients
+
+    mkConfig :: Environment -> API_ID -> API_SECRET -> IO (Environment, API_ID, API_SECRET)
+    mkConfig env apiid apikey = do
+        return (env, apiid, apikey)
+
+tests :: IO (Environment, API_ID, API_SECRET) -> TestTree
+tests config = testGroup "" [instanceProps, unitTests config]
+
+unitTests :: IO (Environment, API_ID, API_SECRET) -> TestTree
+unitTests config = testGroup "\nAPI unit tests"
+  [ testCase "Show API credentials" $ do
+        (env, apiId, apiSecret) <- config
+        print env
+        print apiId
+        print apiSecret
+  ]
+
+instanceProps :: TestTree
+instanceProps = testGroup "Properties" []

--- a/rest/haskell-bitmex-rest.cabal
+++ b/rest/haskell-bitmex-rest.cabal
@@ -57,6 +57,9 @@ library
     , case-insensitive
     , microlens >= 0.4.3 && <0.5
     , deepseq >= 1.4 && <1.6
+    , memory
+    , cryptonite
+
   exposed-modules:
       BitMEX
       BitMEX.API

--- a/rest/lib/BitMEX/API.hs
+++ b/rest/lib/BitMEX/API.hs
@@ -71,7 +71,6 @@ import GHC.Base ((<|>))
 import Prelude ((==),(/=),($), (.),(<$>),(<*>),(>>=),Maybe(..),Bool(..),Char,Double,FilePath,Float,Int,Integer,String,fmap,undefined,mempty,maybe,pure,Monad,Applicative,Functor, show, filter)
 import qualified Prelude as P
 
-import Debug.Trace
 -- * Operations
 
 
@@ -1417,7 +1416,7 @@ orderCancel
 orderCancel _  _ =
   _mkRequest "DELETE" ["/order"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
+    `_hasAuthType` (P.Proxy :: P.Proxy AuthBitMEXApiMAC)
 
 data OrderCancel
 
@@ -1688,7 +1687,7 @@ orderNew
 orderNew _  _ (Symbol symbol) =
   _mkRequest "POST" ["/order"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
+    `_hasAuthType` (P.Proxy :: P.Proxy AuthBitMEXApiMAC)
     `addForm` toForm ("symbol", symbol)
 
 data OrderNew
@@ -3697,7 +3696,7 @@ generateMessage req =
             ParamBodyFormUrlEncoded form -> BCL.unpack $ WH.urlEncodeForm form
             -- FIX ME! ParamBodyMultipartFormData parts ->... not implemented"
 
-     in BC.pack $ traceShowId
+     in BC.pack $ {- traceShowId -}
             ( verb
             <> BCL.unpack path
             <> BC.unpack (NH.renderQuery True query)

--- a/rest/lib/BitMEX/API.hs
+++ b/rest/lib/BitMEX/API.hs
@@ -87,7 +87,6 @@ aPIKeyDisable
 aPIKeyDisable _  _ (ApiKeyId apiKeyId) =
   _mkRequest "POST" ["/apiKey/disable"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("apiKeyID", apiKeyId)
 
@@ -127,7 +126,6 @@ aPIKeyEnable
 aPIKeyEnable _  _ (ApiKeyId apiKeyId) =
   _mkRequest "POST" ["/apiKey/enable"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("apiKeyID", apiKeyId)
 
@@ -164,7 +162,6 @@ aPIKeyGet
 aPIKeyGet  _ =
   _mkRequest "GET" ["/apiKey"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data APIKeyGet
@@ -209,7 +206,6 @@ aPIKeyNew
 aPIKeyNew _  _ =
   _mkRequest "POST" ["/apiKey"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data APIKeyNew
@@ -273,7 +269,6 @@ aPIKeyRemove
 aPIKeyRemove _  _ (ApiKeyId apiKeyId) =
   _mkRequest "DELETE" ["/apiKey"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("apiKeyID", apiKeyId)
 
@@ -348,7 +343,6 @@ announcementGetUrgent
 announcementGetUrgent  _ =
   _mkRequest "GET" ["/announcement/urgent"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data AnnouncementGetUrgent
@@ -504,7 +498,6 @@ chatNew
 chatNew _  _ (Message message) =
   _mkRequest "POST" ["/chat"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("message", message)
 
@@ -550,7 +543,6 @@ executionGet
 executionGet  _ =
   _mkRequest "GET" ["/execution"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data ExecutionGet
@@ -626,7 +618,6 @@ executionGetTradeHistory
 executionGetTradeHistory  _ =
   _mkRequest "GET" ["/execution/tradeHistory"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data ExecutionGetTradeHistory
@@ -1240,7 +1231,6 @@ notificationGet
 notificationGet  _ =
   _mkRequest "GET" ["/notification"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data NotificationGet
@@ -1282,7 +1272,6 @@ orderAmend
 orderAmend _  _ =
   _mkRequest "PUT" ["/order"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data OrderAmend
@@ -1377,7 +1366,6 @@ orderAmendBulk
 orderAmendBulk _  _ =
   _mkRequest "PUT" ["/order/bulk"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data OrderAmendBulk
@@ -1422,7 +1410,6 @@ orderCancel
 orderCancel _  _ =
   _mkRequest "DELETE" ["/order"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data OrderCancel
@@ -1475,7 +1462,6 @@ orderCancelAll
 orderCancelAll _  _ =
   _mkRequest "DELETE" ["/order/all"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data OrderCancelAll
@@ -1531,7 +1517,6 @@ orderCancelAllAfter
 orderCancelAllAfter _  _ (Timeout timeout) =
   _mkRequest "POST" ["/order/cancelAllAfter"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("timeout", timeout)
 
@@ -1573,7 +1558,6 @@ orderClosePosition
 orderClosePosition _  _ (Symbol symbol) =
   _mkRequest "POST" ["/order/closePosition"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("symbol", symbol)
 
@@ -1617,7 +1601,6 @@ orderGetOrders
 orderGetOrders  _ =
   _mkRequest "GET" ["/order"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data OrderGetOrders
@@ -1698,7 +1681,6 @@ orderNew
 orderNew _  _ (Symbol symbol) =
   _mkRequest "POST" ["/order"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("symbol", symbol)
 
@@ -1829,7 +1811,6 @@ orderNewBulk
 orderNewBulk _  _ =
   _mkRequest "POST" ["/order/bulk"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data OrderNewBulk
@@ -1952,7 +1933,6 @@ positionGet
 positionGet  _ =
   _mkRequest "GET" ["/position"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data PositionGet
@@ -2008,7 +1988,6 @@ positionIsolateMargin
 positionIsolateMargin _  _ (Symbol symbol) =
   _mkRequest "POST" ["/position/isolate"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("symbol", symbol)
 
@@ -2056,7 +2035,6 @@ positionTransferIsolatedMargin
 positionTransferIsolatedMargin _  _ (Symbol symbol) (Amount amount) =
   _mkRequest "POST" ["/position/transferMargin"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("symbol", symbol)
     `addForm` toForm ("amount", amount)
@@ -2100,7 +2078,6 @@ positionUpdateLeverage
 positionUpdateLeverage _  _ (Symbol symbol) (Leverage leverage) =
   _mkRequest "POST" ["/position/leverage"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("symbol", symbol)
     `addForm` toForm ("leverage", leverage)
@@ -2144,7 +2121,6 @@ positionUpdateRiskLimit
 positionUpdateRiskLimit _  _ (Symbol symbol) (RiskLimit riskLimit) =
   _mkRequest "POST" ["/position/riskLimit"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("symbol", symbol)
     `addForm` toForm ("riskLimit", riskLimit)
@@ -2840,7 +2816,6 @@ userConfirmEnableTFA
 userConfirmEnableTFA _  _ (Token token) =
   _mkRequest "POST" ["/user/confirmEnableTFA"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("token", token)
 
@@ -2920,7 +2895,6 @@ userDisableTFA
 userDisableTFA _  _ (Token token) =
   _mkRequest "POST" ["/user/disableTFA"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("token", token)
 
@@ -2962,7 +2936,6 @@ userGet
 userGet  _ =
   _mkRequest "GET" ["/user"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGet
@@ -2998,7 +2971,6 @@ userGetAffiliateStatus
 userGetAffiliateStatus  _ =
   _mkRequest "GET" ["/user/affiliateStatus"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGetAffiliateStatus
@@ -3034,7 +3006,6 @@ userGetCommission
 userGetCommission  _ =
   _mkRequest "GET" ["/user/commission"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGetCommission
@@ -3070,7 +3041,6 @@ userGetDepositAddress
 userGetDepositAddress  _ =
   _mkRequest "GET" ["/user/depositAddress"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGetDepositAddress
@@ -3109,7 +3079,6 @@ userGetMargin
 userGetMargin  _ =
   _mkRequest "GET" ["/user/margin"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGetMargin
@@ -3148,7 +3117,6 @@ userGetWallet
 userGetWallet  _ =
   _mkRequest "GET" ["/user/wallet"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGetWallet
@@ -3187,7 +3155,6 @@ userGetWalletHistory
 userGetWalletHistory  _ =
   _mkRequest "GET" ["/user/walletHistory"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGetWalletHistory
@@ -3226,7 +3193,6 @@ userGetWalletSummary
 userGetWalletSummary  _ =
   _mkRequest "GET" ["/user/walletSummary"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserGetWalletSummary
@@ -3298,7 +3264,6 @@ userLogoutAll
 userLogoutAll  _ =
   _mkRequest "POST" ["/user/logoutAll"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserLogoutAll
@@ -3374,7 +3339,6 @@ userRequestEnableTFA
 userRequestEnableTFA _  _ =
   _mkRequest "POST" ["/user/requestEnableTFA"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserRequestEnableTFA
@@ -3422,7 +3386,6 @@ userRequestWithdrawal
 userRequestWithdrawal _  _ (Currency currency) (Amount amount) (Address address) =
   _mkRequest "POST" ["/user/requestWithdrawal"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("currency", currency)
     `addForm` toForm ("amount", amount)
@@ -3474,7 +3437,6 @@ userSavePreferences
 userSavePreferences _  _ (Prefs prefs) =
   _mkRequest "POST" ["/user/preferences"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
     `addForm` toForm ("prefs", prefs)
 
@@ -3518,7 +3480,6 @@ userUpdate
 userUpdate _  _ =
   _mkRequest "PUT" ["/user"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiKey)
-    `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiNonce)
     `_hasAuthType` (P.Proxy :: P.Proxy AuthApiKeyApiSignature)
 
 data UserUpdate

--- a/rest/lib/BitMEX/Client.hs
+++ b/rest/lib/BitMEX/Client.hs
@@ -50,7 +50,6 @@ import Data.Monoid ((<>))
 import Data.Text (Text)
 import GHC.Exts (IsString(..))
 
-import Debug.Trace
 -- * Dispatch
 
 -- ** Lbs

--- a/rest/lib/BitMEX/Client.hs
+++ b/rest/lib/BitMEX/Client.hs
@@ -50,6 +50,7 @@ import Data.Monoid ((<>))
 import Data.Text (Text)
 import GHC.Exts (IsString(..))
 
+import Debug.Trace
 -- * Dispatch
 
 -- ** Lbs
@@ -139,7 +140,7 @@ dispatchInitUnsafe manager config (InitRequest req) = do
   runConfigLogWithExceptions src config $
     do _log src levelInfo requestLogMsg
        _log src levelDebug requestDbgLogMsg
-       res <- P.liftIO $ NH.httpLbs req manager
+       res <- P.liftIO $ NH.httpLbs ({-traceShowId -} req) manager
        _log src levelInfo (responseLogMsg res)
        _log src levelDebug ((T.pack . show) res)
        return res

--- a/rest/lib/BitMEX/Logging.hs
+++ b/rest/lib/BitMEX/Logging.hs
@@ -81,6 +81,11 @@ stderrLoggingContext cxt = do
     handleScribe <- LG.mkHandleScribe LG.ColorIfTerminal IO.stderr (LG.permitItem LG.InfoS) LG.V2
     LG.registerScribe "stderr" handleScribe LG.defaultScribeSettings cxt
 
+stderrLevelLoggingContext :: LG.Severity -> LogContext -> IO LogContext
+stderrLevelLoggingContext level cxt = do
+    handleScribe <- LG.mkHandleScribe LG.ColorIfTerminal IO.stderr (LG.permitItem level) LG.V2
+    LG.registerScribe "stderr" handleScribe LG.defaultScribeSettings cxt
+
 -- * Null logger
 
 -- | Disables Katip logging


### PR DESCRIPTION
BitMEX load shedding really shows its teeth when there are large price swings. This adds some optional retry functionality for when we receive an 503 HTTP status and just want to retry a REST request. Following on from #22, sorry about the long cascade, I will keep it in check from now on.