### PR TITLE
Fix parsing of websocket messages during position close

### DIFF
--- a/client/haskell-bitmex-client.cabal
+++ b/client/haskell-bitmex-client.cabal
@@ -54,6 +54,7 @@ library
                      , vector >=0.10.9 && <0.13
                      , websockets >= 0.12
                      , wuss >= 1.1
+                     , unordered-containers
   hs-source-dirs:      lib
   default-language:    Haskell2010
   default-extensions:  DataKinds

--- a/client/test/Test.hs
+++ b/client/test/Test.hs
@@ -132,6 +132,11 @@ unitTests config = testGroup "\nAPI unit tests"
             Just _ -> return ()
             Nothing -> assertFailure "Could not parse funding fee execution message."
 
+    , testCase "Websocket parse position close" $ do
+        case decode sampleClosePositionMsg :: Maybe Response of
+            Just _ -> return ()
+            Nothing -> assertFailure "Could not parse position close message."
+
     , testCase "Multiple retries upon 503 HTTP Status" $ do
         ref   <- newIORef 0
         resp  <- retryOn503 9 (fakeDispatch ref)
@@ -196,3 +201,13 @@ fakeDispatch ref = do
     modifyIORef ref (+1)
     return sampleTooBusyResponse
 --------------------------------------------------------------------------------
+
+sampleClosePositionMsg =
+    "{\"table\":\"order\",\"action\":\"insert\",\"data\":[{\"orderID\":\"af3e3796-f1a4-47a1-8782-db6a7de1cd5e\","
+    <> "\"clOrdID\":\"\",\"clOrdLinkID\":\"\",\"account\":1112233,\"symbol\":\"XBTUSD\",\"side\":\"\",\"simpleOrderQty\":null,"
+    <> "\"orderQty\":null,\"price\":null,\"displayQty\":null,\"stopPx\":null,\"pegOffsetValue\":null,\"pegPriceType\":\"\","
+    <> "\"currency\":\"USD\",\"settlCurrency\":\"XBt\",\"ordType\":\"Market\",\"timeInForce\":\"ImmediateOrCancel\","
+    <> "\"execInst\":\"Close\",\"contingencyType\":\"\",\"exDestination\":\"XBME\",\"ordStatus\":\"New\",\"triggered\":\"\","
+    <> "\"workingIndicator\":false,\"ordRejReason\":\"\",\"simpleLeavesQty\":null,\"leavesQty\":null,\"simpleCumQty\":null,"
+    <> "\"cumQty\":0,\"avgPx\":null,\"multiLegReportingType\":\"SingleSecurity\",\"text\":\"Position Close from www.bitmex.com\","
+    <> "\"transactTime\":\"2019-07-03T05:13:54.838Z\",\"timestamp\":\"2019-07-03T05:13:54.838Z\"}]}"


### PR DESCRIPTION
When closing your position through the web, bitmex creates a market order
but it does not give it a "side" on the websocket message that announces
the order's creation. This was failing the parser.

(Also cleaned up the complicated FromJSON instance for `RespExecution`)