### PR TITLE
Add retry policy

### DIFF
--- a/client/haskell-bitmex-client.cabal
+++ b/client/haskell-bitmex-client.cabal
@@ -25,6 +25,8 @@ library
                     , BitMEXClient.Wrapper.Logging
                     , BitMEXClient.Wrapper.Types
                     , BitMEXClient.Wrapper.Util
+                    , BitMEXClient.Wrapper.Retry
+
   other-modules: BitMEXClient.CustomPrelude
   ghc-options: -Wall
                -funbox-strict-fields
@@ -55,6 +57,8 @@ library
                      , websockets >= 0.12
                      , wuss >= 1.1
                      , unordered-containers
+                     , monad-time
+
   hs-source-dirs:      lib
   default-language:    Haskell2010
   default-extensions:  DataKinds

--- a/client/lib/BitMEXClient/WebSockets/Types/General.hs
+++ b/client/lib/BitMEXClient/WebSockets/Types/General.hs
@@ -70,6 +70,9 @@ data Symbol
     | ETHM18
     | LTCM18
     | XRPM18
+    | XBTM19
+    | XBTU19
+    | XBTZ19
     deriving (Eq, Show, Generic)
 
 instance ToJSON Symbol

--- a/client/lib/BitMEXClient/WebSockets/Types/General.hs
+++ b/client/lib/BitMEXClient/WebSockets/Types/General.hs
@@ -73,6 +73,19 @@ data Symbol
     | XBTM19
     | XBTU19
     | XBTZ19
+
+    | XBTH20
+    | XBTM20
+    | XBTU20
+    | XBTZ20
+
+    | ETHUSD
+
+    | ETHZ19
+    | ETHH20
+    | ETHM20
+    | ETHU20
+    | ETHZ20
     deriving (Eq, Show, Generic)
 
 instance ToJSON Symbol

--- a/client/lib/BitMEXClient/Wrapper.hs
+++ b/client/lib/BitMEXClient/Wrapper.hs
@@ -3,6 +3,7 @@ module BitMEXClient.Wrapper
     ) where
 
 import           BitMEXClient.Wrapper.API     as X
+import           BitMEXClient.Wrapper.Retry   as X
 import           BitMEXClient.Wrapper.Logging as X
 import           BitMEXClient.Wrapper.Types   as X
 import           BitMEXClient.Wrapper.Util    as X

--- a/client/lib/BitMEXClient/Wrapper/Retry.hs
+++ b/client/lib/BitMEXClient/Wrapper/Retry.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module BitMEXClient.Wrapper.Retry
+    ( Delay
+    , RetryAction(..)
+    , RetryPolicy
+    , retry
+    , retryXTimesWithDelayPolicy
+    , exponential429BackOff
+    , ThreadSleep
+    , threadSleep
+    ) where
+
+import Prelude
+import Data.Either              (Either(..), lefts)
+import Data.Time                (UTCTime)
+
+import Control.Monad.Time       (MonadTime, currentTime)
+import Control.Concurrent       (threadDelay)
+
+import Network.HTTP.Client      (Response(..))
+import Network.HTTP.Types       (Status(..), serviceUnavailable503, badGateway502, tooManyRequests429)
+
+import BitMEX                   (MimeResult(..), MimeError(..))
+
+----------------------------------------
+class ThreadSleep m where
+    threadSleep :: Int -> m ()
+
+instance ThreadSleep IO where
+    threadSleep = threadDelay
+
+----------------------------------------
+-- | This should really only be a Natural number (in microseconds), rather than an Int
+type Delay = Int
+
+data RetryAction res = ReturnResult (MimeResult res) | RetryAfter Delay
+
+-- | Given the currentTime and a (possibly empty) list of what happened on previous attempts, tells us what to do next.
+type RetryPolicy res = UTCTime -> [MimeResult res] -> RetryAction res
+
+----------------------------------------
+retry :: forall m res. (MonadTime m, ThreadSleep m) => RetryPolicy res -> m (MimeResult res) -> m (MimeResult res)
+retry policy action = do
+    now <- currentTime
+    retry' now []
+  where
+    retry' :: UTCTime -> [MimeResult res] -> m (MimeResult res)
+    retry' now previousResults
+        | ReturnResult res <- policy now previousResults = pure res
+        | RetryAfter delay <- policy now previousResults = do
+                                                            threadSleep delay
+                                                            res  <- action -- may take a while
+                                                            now' <- currentTime
+                                                            retry' now' (res : previousResults)
+        | otherwise = error "retry' - RetryAction should only have 2 constructors, this should be impossible!"
+
+----------------------------------------
+-- This is an example policy.
+-- It retries up to X times (for a maximum of X+1 attempts in total)
+-- while receiving errors in the designated list (e.g. [503,502,429]).
+-- It uses the specified delay between attempts.
+retryXTimesWithDelayPolicy :: [Int] -> Int -> Delay -> RetryPolicy res
+retryXTimesWithDelayPolicy          _     _         _ _      [] = RetryAfter 0  -- never attempted, try immediately
+retryXTimesWithDelayPolicy errorCodes count uSecDelay _ results =
+    let lastResult = head results
+     in case lastResult of
+            -- success
+            MimeResult {mimeResult = Right _} -> ReturnResult lastResult
+            -- retry-able failure
+            MimeResult {mimeResult = Left MimeError {mimeErrorResponse = response}}
+                | Status{statusCode = errorCode} <- responseStatus response
+                , errorCode `elem` errorCodes -> if length results <= count
+                                                    then RetryAfter   uSecDelay
+                                                    else ReturnResult lastResult
+            -- fatal failure
+            _ -> ReturnResult lastResult
+
+
+----------------------------------------
+-- This policy does an exponential back-off (2x) every time it hits a 429.
+-- The delay increases maxes out at 32 seconds. If another 429 is received
+-- after that, we give up. This may be too lenient, it might be safer to
+-- force an error if waiting for 16 seconds did not solve the problem.
+--
+-- If it gets a 503 or 502, it retries (immediately for 503). Those errors are
+-- not our own fault, but they keep the execution thread tied up. If execution
+-- is single threaded and is busy retrying, no other orders can execute and
+-- may just be queued up. Adding unnecessary retry delays increases the chance
+-- that once queued up orders are placed, their prices will be outdated.
+--
+-- This gives up after:
+--  - 20 errors of type 502
+--  - 30 errors of type 503 (load shedding)
+--  -  6 errors of type 429 (rate limiting)
+--
+-- Because some retries are immediate, we may actually hit those high error counts.
+--
+exponential429BackOff :: RetryPolicy res
+exponential429BackOff _ []      = RetryAfter 0  -- never attempted, try immediately
+exponential429BackOff _ results = case lastResult of
+    -- success
+    MimeResult {mimeResult = Right _} -> ReturnResult lastResult
+    -- retry-able failure
+    MimeResult {mimeResult = Left (MimeError {mimeErrorResponse = response})}
+        | responseStatus response == badGateway502         && errorCount badGateway502         < 20 -> RetryAfter 100000
+        | responseStatus response == serviceUnavailable503 && errorCount serviceUnavailable503 < 30 -> RetryAfter 0
+        | responseStatus response == tooManyRequests429    && errorCount tooManyRequests429    <  6 -> RetryAfter (2 ^ errorCount tooManyRequests429 * 1000000)
+    -- fatal failure
+    _ -> ReturnResult lastResult
+
+  where
+    lastResult = head results
+
+    errorCount :: Status -> Int
+    errorCount errorType = length $ filter (== errorType) $ fmap (responseStatus . mimeErrorResponse) $ lefts $ fmap mimeResult $ results

--- a/client/test/Test.hs
+++ b/client/test/Test.hs
@@ -139,7 +139,7 @@ unitTests config = testGroup "\nAPI unit tests"
 
     , testCase "Multiple retries upon 503 HTTP Status" $ do
         ref   <- newIORef 0
-        resp  <- retryOn503 9 (fakeDispatch ref)
+        resp  <- retryOn [502, 503, 429] 50000 9 (fakeDispatch ref)
         count <- readIORef ref
         assertEqual "retry response status does not match action status"
             (NH.responseStatus $ mimeResultResponse sampleTooBusyResponse)

--- a/client/test/Test.hs
+++ b/client/test/Test.hs
@@ -139,7 +139,7 @@ unitTests config = testGroup "\nAPI unit tests"
 
     , testCase "Multiple retries upon 503 HTTP Status" $ do
         ref   <- newIORef 0
-        resp  <- retryOn [502, 503, 429] 50000 9 (fakeDispatch ref)
+        resp  <- retry (retryXTimesWithDelayPolicy [502, 503, 429] 9 20000) (fakeDispatch ref)
         count <- readIORef ref
         assertEqual "retry response status does not match action status"
             (NH.responseStatus $ mimeResultResponse sampleTooBusyResponse)

--- a/client/test/Test.hs
+++ b/client/test/Test.hs
@@ -3,26 +3,24 @@
 
 module Main where
 
-import Data.Typeable (Proxy(..))
+import           Data.Typeable            (Proxy(..))
+import           Data.IORef
+import           Data.Text                (pack)
+import           Data.Aeson               (decode)
+import           Data.Time.Clock.POSIX    (getPOSIXTime)
 
-import Test.Tasty
-import Test.Tasty.Options
-import Test.Tasty.HUnit
-
-import Data.Text                (pack)
-import Data.Aeson               (decode)
-import Data.Time.Clock.POSIX    (getPOSIXTime)
-import Network.HTTP.Client      (newManager)
-import Network.HTTP.Client.TLS  (tlsManagerSettings)
-
+import           Network.HTTP.Client      (newManager)
+import           Network.HTTP.Client.TLS  (tlsManagerSettings)
 import qualified Network.HTTP.Client.Internal as NH
 import qualified Network.HTTP.Types           as NH
-import           Data.IORef
 
-import BitMEX
+import           BitMEX
+import           BitMEXClient hiding      (error, Position, Order)
+import qualified BitMEXClient as BMC      (Symbol(..))
 
-import           BitMEXClient hiding (error, Position, Order)
-import qualified BitMEXClient as BMC (Symbol(..))
+import           Test.Tasty
+import           Test.Tasty.Options
+import           Test.Tasty.HUnit
 
 ----------------------------------------
 newtype API_ID     = API_ID      String deriving (Show, Eq)
@@ -139,12 +137,40 @@ unitTests config = testGroup "\nAPI unit tests"
 
     , testCase "Multiple retries upon 503 HTTP Status" $ do
         ref   <- newIORef 0
-        resp  <- retry (retryXTimesWithDelayPolicy [502, 503, 429] 9 20000) (fakeDispatch ref)
+        resp  <- retry exponential429BackOff (fakeDispatch (take 50 $ repeat sample503Response) ref)
         count <- readIORef ref
         assertEqual "retry response status does not match action status"
-            (NH.responseStatus $ mimeResultResponse sampleTooBusyResponse)
+            (NH.responseStatus $ mimeResultResponse sample503Response)
             (NH.responseStatus $ mimeResultResponse resp)
-        assertEqual "Retried wrong number of times" 10 count
+        assertEqual "Retried wrong number of times" 30 count
+
+    , testCase "Multiple retries upon 502 HTTP Status" $ do
+        ref   <- newIORef 0
+        resp  <- retry exponential429BackOff (fakeDispatch (take 50 $ repeat sample502Response) ref)
+        count <- readIORef ref
+        assertEqual "retry response status does not match action status"
+            (NH.responseStatus $ mimeResultResponse sample502Response)
+            (NH.responseStatus $ mimeResultResponse resp)
+        assertEqual "Retried wrong number of times" 20 count
+
+    , testCase "Multiple retries upon 429 HTTP Status" $ do
+        ref   <- newIORef 0
+        resp  <- retry exponential429BackOff (fakeDispatch (take 50 $ repeat sample429Response) ref)
+        count <- readIORef ref
+        assertEqual "retry response status does not match action status"
+            (NH.responseStatus $ mimeResultResponse sample429Response)
+            (NH.responseStatus $ mimeResultResponse resp)
+        assertEqual "Retried wrong number of times" 6 count
+
+    , testCase "Success after retries of different HTTP Status" $ do
+        ref   <- newIORef 0
+        resp  <- retry exponential429BackOff (fakeDispatch sampleAttempts ref)
+        count <- readIORef ref
+        assertEqual "retry response status does not match action status"
+            (NH.responseStatus $ mimeResultResponse sampleSuccessResponse)
+            (NH.responseStatus $ mimeResultResponse resp)
+        assertEqual "Retried wrong number of times" 15 count
+
     ]
 
 instanceProps :: TestTree
@@ -165,8 +191,8 @@ sampleFundingExecutionMsg =
     <> "\"transactTime\":\"2019-06-23T12:00:00.000Z\",\"timestamp\":\"2019-06-23T12:00:01.438Z\"}]}"
 
 --------------------------------------------------------------------------------
-sampleTooBusyResponse :: MimeResult res
-sampleTooBusyResponse =  MimeResult
+sample503Response :: MimeResult res
+sample503Response =  MimeResult
     { mimeResult = Left
         ( MimeError
             { mimeError = "error statusCode: 503"
@@ -196,10 +222,116 @@ sampleTooBusyResponse =  MimeResult
         }
     }
 
-fakeDispatch :: IORef Int -> IO (MimeResult ())
-fakeDispatch ref = do
+--------------------------------------------------------------------------------
+sample429Response :: MimeResult res
+sample429Response =  MimeResult
+    { mimeResult = Left
+        ( MimeError
+            { mimeError = "error statusCode: 429"
+            , mimeErrorResponse = NH.Response
+                { NH.responseStatus = NH.Status
+                    { NH.statusCode = 429
+                    , NH.statusMessage = "Too Many Requests"
+                    }
+                , NH.responseVersion = NH.http11
+                , NH.responseHeaders = []
+                , NH.responseBody = "{\"error\":{\"message\":\"Dude, just slow down, will you.\",\"name\":\"HTTPError\"}}"
+                , NH.responseCookieJar = NH.CJ {NH.expose = []}
+                , NH.responseClose' = undefined
+                }
+            }
+        )
+    , mimeResultResponse = NH.Response
+        { NH.responseStatus = NH.Status
+            { NH.statusCode = 429
+            , NH.statusMessage = "Too Many Requests"
+            }
+        , NH.responseVersion = NH.http11
+        , NH.responseHeaders = []
+        , NH.responseBody = "{\"error\":{\"message\":\"Dude, just slow down, will you.\",\"name\":\"HTTPError\"}}"
+        , NH.responseCookieJar = NH.CJ {NH.expose = []}
+        , NH.responseClose' = undefined
+        }
+    }
+
+
+--------------------------------------------------------------------------------
+sample502Response :: MimeResult res
+sample502Response =  MimeResult
+    { mimeResult = Left
+        ( MimeError
+            { mimeError = "error statusCode: 502"
+            , mimeErrorResponse = NH.Response
+                { NH.responseStatus = NH.Status
+                    { NH.statusCode = 502
+                    , NH.statusMessage = "Bad Gateway"
+                    }
+                , NH.responseVersion = NH.http11
+                , NH.responseHeaders = []
+                , NH.responseBody = "{\"error\":{\"message\":\"Yowl, sorry, can't get you through.\",\"name\":\"HTTPError\"}}"
+                , NH.responseCookieJar = NH.CJ {NH.expose = []}
+                , NH.responseClose' = undefined
+                }
+            }
+        )
+    , mimeResultResponse = NH.Response
+        { NH.responseStatus = NH.Status
+            { NH.statusCode = 503
+            , NH.statusMessage = "Service Unavailable"
+            }
+        , NH.responseVersion = NH.http11
+        , NH.responseHeaders = []
+        , NH.responseBody = "{\"error\":{\"message\":\"Yowl, sorry, can't get you through.\",\"name\":\"HTTPError\"}}"
+        , NH.responseCookieJar = NH.CJ {NH.expose = []}
+        , NH.responseClose' = undefined
+        }
+    }
+
+
+sampleSuccessResponse :: MimeResult ()
+sampleSuccessResponse = MimeResult
+    { mimeResult = Right ()
+    , mimeResultResponse = NH.Response
+        { NH.responseStatus = NH.Status
+            { NH.statusCode = 200
+            , NH.statusMessage = "OK"
+            }
+        , NH.responseVersion = NH.http11
+        , NH.responseHeaders = []
+        , NH.responseBody = "We're good!"
+        , NH.responseCookieJar = NH.CJ {NH.expose = []}
+        , NH.responseClose' = undefined
+        }
+    }
+
+sampleAttempts :: [MimeResult ()]
+sampleAttempts =
+    [ sample502Response      -- we hit this at time 0
+
+    , sample429Response      -- we hit this at time 0.1
+    , sample429Response      -- 2.1
+
+    , sample503Response      -- 2.1 + 4 = 6.1
+    , sample503Response
+    , sample503Response
+    , sample503Response
+    , sample503Response
+    , sample503Response
+    , sample503Response
+    , sample503Response
+
+    , sample429Response      --  6.1
+    , sample429Response      --  6.1 +  8 = 14.1
+    , sample429Response      -- 14.1 + 16 = 30.1
+
+    , sampleSuccessResponse  -- 30.1 + 32 = 62.1
+    ]
+
+fakeDispatch :: [MimeResult ()] -> IORef Int -> IO (MimeResult ())
+fakeDispatch responses ref = do
+    i <- readIORef ref
     modifyIORef ref (+1)
-    return sampleTooBusyResponse
+    return (responses !! i)
 --------------------------------------------------------------------------------
 
 sampleClosePositionMsg =

--- a/client/test/Test.hs
+++ b/client/test/Test.hs
@@ -137,7 +137,7 @@ unitTests config = testGroup "\nAPI unit tests"
 
     , testCase "Multiple retries upon 503 HTTP Status" $ do
         ref   <- newIORef 0
-        resp  <- retry exponential429BackOff (fakeDispatch (take 50 $ repeat sample503Response) ref)
+        resp  <- retry exponential429BackOff (fakeDispatch (repeat sample503Response) ref)
         count <- readIORef ref
         assertEqual "retry response status does not match action status"
             (NH.responseStatus $ mimeResultResponse sample503Response)
@@ -146,7 +146,7 @@ unitTests config = testGroup "\nAPI unit tests"
 
     , testCase "Multiple retries upon 502 HTTP Status" $ do
         ref   <- newIORef 0
-        resp  <- retry exponential429BackOff (fakeDispatch (take 50 $ repeat sample502Response) ref)
+        resp  <- retry exponential429BackOff (fakeDispatch (repeat sample502Response) ref)
         count <- readIORef ref
         assertEqual "retry response status does not match action status"
             (NH.responseStatus $ mimeResultResponse sample502Response)
@@ -155,7 +155,7 @@ unitTests config = testGroup "\nAPI unit tests"
 
     , testCase "Multiple retries upon 429 HTTP Status" $ do
         ref   <- newIORef 0
-        resp  <- retry exponential429BackOff (fakeDispatch (take 50 $ repeat sample429Response) ref)
+        resp  <- retry exponential429BackOff (fakeDispatch (repeat sample429Response) ref)
         count <- readIORef ref
         assertEqual "retry response status does not match action status"
             (NH.responseStatus $ mimeResultResponse sample429Response)
@@ -167,7 +167,7 @@ unitTests config = testGroup "\nAPI unit tests"
         resp  <- retry exponential429BackOff (fakeDispatch sampleAttempts ref)
         count <- readIORef ref
         assertEqual "retry response status does not match action status"
-            (NH.responseStatus $ mimeResultResponse sampleSuccessResponse)
+            (NH.responseStatus $ mimeResultResponse sample200OKResponse)
             (NH.responseStatus $ mimeResultResponse resp)
         assertEqual "Retried wrong number of times" 15 count
 
@@ -288,8 +288,8 @@ sample502Response =  MimeResult
     }
 
 
-sampleSuccessResponse :: MimeResult ()
-sampleSuccessResponse = MimeResult
+sample200OKResponse :: MimeResult ()
+sample200OKResponse = MimeResult
     { mimeResult = Right ()
     , mimeResultResponse = NH.Response
         { NH.responseStatus = NH.Status
@@ -324,7 +324,7 @@ sampleAttempts =
     , sample429Response      --  6.1 +  8 = 14.1
     , sample429Response      -- 14.1 + 16 = 30.1
 
-    , sampleSuccessResponse  -- 30.1 + 32 = 62.1
+    , sample200OKResponse    -- 30.1 + 32 = 62.1
     ]
 
 fakeDispatch :: [MimeResult ()] -> IORef Int -> IO (MimeResult ())


### PR DESCRIPTION
This factors out retry policies to allow for a more consistent way to retry HTTP requests upon BitMEX's load shedding (503) and 429 (rate limiting) errors.